### PR TITLE
DDD-82 Authorization roles

### DIFF
--- a/src/main/java/lt/vu/application/exception/ForbiddenException.java
+++ b/src/main/java/lt/vu/application/exception/ForbiddenException.java
@@ -1,0 +1,8 @@
+package lt.vu.application.exception;
+
+public abstract class ForbiddenException extends Exception {
+
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/lt/vu/application/security/config/Claims.java
+++ b/src/main/java/lt/vu/application/security/config/Claims.java
@@ -3,5 +3,6 @@ package lt.vu.application.security.config;
 public abstract class Claims {
 
     public static final String USER_ID = "userId";
+    public static final String ROLES = "roles";
     public static final String ISSUER = "Delivery Service";
 }

--- a/src/main/java/lt/vu/application/security/exception/AccessForbiddenException.java
+++ b/src/main/java/lt/vu/application/security/exception/AccessForbiddenException.java
@@ -1,0 +1,12 @@
+package lt.vu.application.security.exception;
+
+import lt.vu.application.exception.ForbiddenException;
+
+public class AccessForbiddenException extends ForbiddenException {
+
+    private static final String message = "Access forbidden";
+
+    public AccessForbiddenException() {
+        super(message);
+    }
+}

--- a/src/main/java/lt/vu/application/security/service/JWTBuilder.java
+++ b/src/main/java/lt/vu/application/security/service/JWTBuilder.java
@@ -17,6 +17,7 @@ public class JWTBuilder {
     public Token build(User user) {
         String jwt = Jwts.builder()
                 .claim(Claims.USER_ID, user.getId())
+                .claim(Claims.ROLES, user.getRoles())
                 .setIssuedAt(new Date())
                 .setIssuer(Claims.ISSUER)
                 // Expires after 30 minutes

--- a/src/main/java/lt/vu/application/user/factory/UserFactory.java
+++ b/src/main/java/lt/vu/application/user/factory/UserFactory.java
@@ -2,10 +2,12 @@ package lt.vu.application.user.factory;
 
 import lt.vu.application.security.service.PasswordHasher;
 import lt.vu.persistence.orm.entities.User;
+import lt.vu.persistence.orm.entities.UserRole;
 import lt.vu.web.api.v1.dto.security.PostRegisterDTO;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import java.util.Collections;
 
 @RequestScoped
 public class UserFactory {
@@ -21,6 +23,7 @@ public class UserFactory {
         user.setPhoneNumber(registerDTO.getPhoneNumber());
         user.setEmail(registerDTO.getEmail());
         user.setPassword(this.passwordHasher.hash(registerDTO.getPassword()));
+        user.setRoles(Collections.singletonList(UserRole.USER));
 
         return user;
     }

--- a/src/main/java/lt/vu/infrastructure/security/Authorized.java
+++ b/src/main/java/lt/vu/infrastructure/security/Authorized.java
@@ -1,5 +1,7 @@
 package lt.vu.infrastructure.security;
 
+import lt.vu.persistence.orm.entities.UserRole;
+
 import javax.ws.rs.NameBinding;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -13,4 +15,6 @@ import java.lang.annotation.Target;
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Authorized {
+
+    String role() default UserRole.USER;
 }

--- a/src/main/java/lt/vu/persistence/orm/entities/User.java
+++ b/src/main/java/lt/vu/persistence/orm/entities/User.java
@@ -5,6 +5,7 @@ import lombok.Setter;
 
 import javax.persistence.*;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Objects;
 
 @Entity
@@ -39,6 +40,11 @@ public class User implements Serializable {
     @ManyToOne(cascade = CascadeType.ALL)
     @JoinColumn(name = "ADDRESS_ID")
     private Address address;
+
+    @ElementCollection(targetClass = String.class)
+    @Column(name = "ROLE")
+    @CollectionTable(name = "USER_ROLE", joinColumns = { @JoinColumn(name = "USER_ID") })
+    private List<String> roles;
 
     public User() {
     }

--- a/src/main/java/lt/vu/persistence/orm/entities/UserRole.java
+++ b/src/main/java/lt/vu/persistence/orm/entities/UserRole.java
@@ -2,6 +2,6 @@ package lt.vu.persistence.orm.entities;
 
 public class UserRole {
 
-    public static String USER = "USER";
-    public static String ADMIN = "ADMIN";
+    public final static String USER = "USER";
+    public final static String ADMIN = "ADMIN";
 }

--- a/src/main/java/lt/vu/persistence/orm/entities/UserRole.java
+++ b/src/main/java/lt/vu/persistence/orm/entities/UserRole.java
@@ -1,0 +1,7 @@
+package lt.vu.persistence.orm.entities;
+
+public class UserRole {
+
+    public static String USER = "USER";
+    public static String ADMIN = "ADMIN";
+}

--- a/src/main/java/lt/vu/web/api/v1/exception/ForbiddenExceptionMapper.java
+++ b/src/main/java/lt/vu/web/api/v1/exception/ForbiddenExceptionMapper.java
@@ -1,0 +1,26 @@
+package lt.vu.web.api.v1.exception;
+
+import lt.vu.application.exception.ForbiddenException;
+import lt.vu.infrastructure.logger.Logger;
+
+import javax.inject.Inject;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class ForbiddenExceptionMapper implements ExceptionMapper<ForbiddenException> {
+
+    @Inject
+    private Logger logger;
+
+    @Override
+    public Response toResponse(ForbiddenException e) {
+        this.logger.error(e);
+
+        return Response
+                .status(Response.Status.FORBIDDEN)
+                .entity(ExceptionDTO.create(e, Response.Status.FORBIDDEN))
+                .build();
+    }
+}

--- a/src/main/resources/META-INF/import.sql
+++ b/src/main/resources/META-INF/import.sql
@@ -36,3 +36,4 @@ insert into `ORDER` (ID, CREATED_AT, STATUS, PICKUP_DATE_TIME, TOTAL_PRICE, PACK
 -- Users
 -- PASSWORD = password
 insert into `USER` (ID, EMAIL, FIRST_NAME, LAST_NAME, PHONE_NUMBER, ADDRESS_ID, PASSWORD) values (1, 'jonas@gmail.com', 'Jonas', 'Jonauskas', 862598745, 1, '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8');
+insert into USER_ROLE (USER_ID, `ROLE`) values (1, 'USER');

--- a/src/main/resources/META-INF/import.sql
+++ b/src/main/resources/META-INF/import.sql
@@ -37,5 +37,10 @@ insert into `ORDER` (ID, CREATED_AT, STATUS, PICKUP_DATE_TIME, TOTAL_PRICE, PACK
 -- PASSWORD = password
 insert into `USER` (ID, EMAIL, FIRST_NAME, LAST_NAME, PHONE_NUMBER, ADDRESS_ID, PASSWORD) values (1, 'jonas@gmail.com', 'Jonas', 'Jonauskas', 862598745, 1, '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8');
 insert into `USER` (ID, EMAIL, FIRST_NAME, LAST_NAME, PHONE_NUMBER, ADDRESS_ID, PASSWORD) values (2, 'admin@gmail.com', 'Admin', 'Admin', 862598745, 1, '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8');
+
+-- Demo user roles
 insert into USER_ROLE (USER_ID, `ROLE`) values (1, 'USER');
+
+-- Admin user roles
+insert into USER_ROLE (USER_ID, `ROLE`) values (2, 'USER');
 insert into USER_ROLE (USER_ID, `ROLE`) values (2, 'ADMIN');

--- a/src/main/resources/META-INF/import.sql
+++ b/src/main/resources/META-INF/import.sql
@@ -36,4 +36,6 @@ insert into `ORDER` (ID, CREATED_AT, STATUS, PICKUP_DATE_TIME, TOTAL_PRICE, PACK
 -- Users
 -- PASSWORD = password
 insert into `USER` (ID, EMAIL, FIRST_NAME, LAST_NAME, PHONE_NUMBER, ADDRESS_ID, PASSWORD) values (1, 'jonas@gmail.com', 'Jonas', 'Jonauskas', 862598745, 1, '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8');
+insert into `USER` (ID, EMAIL, FIRST_NAME, LAST_NAME, PHONE_NUMBER, ADDRESS_ID, PASSWORD) values (2, 'admin@gmail.com', 'Admin', 'Admin', 862598745, 1, '5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8');
 insert into USER_ROLE (USER_ID, `ROLE`) values (1, 'USER');
+insert into USER_ROLE (USER_ID, `ROLE`) values (2, 'ADMIN');


### PR DESCRIPTION
This MR adds the possibility to allow specific endpoints only for specific user roles.

Usage: `@Authorized(role = UserRole.ADMIN)`. Defaults to `UserRole.USER` (regular user). If specified role has not been met, the backend returns HTTP 403:
```
{
    "statusCode": 403,
    "message": "Access forbidden"
}
```

User roles can be accessed in frontend by decoding JWT token.